### PR TITLE
Add Resource Library page link to footer and update Resources page heading

### DIFF
--- a/frontend/app/resources/page.jsx
+++ b/frontend/app/resources/page.jsx
@@ -6,8 +6,8 @@ export default function Component() {
     <div key="1" className="bg-white text-gray-700 pt-10">
       <main>
         <section className="container mx-auto px-4 py-16 text-center">
-          <h1 className="text-5xl font-bold mb-4 text-primary">Resources</h1>
-          <p className="mb-8">Explore our range of resources. Learn more about our products and how to use them.</p>
+          <h1 className="text-5xl font-bold mb-4 text-primary">Resource Library</h1>
+          <p className="mb-8">Explore our Resource Library for guides, tutorials, and FAQs about SnapshortURL.</p>
         </section>
         <section className="container mx-auto px-4 py-16">
           <div className="lg:ml-32 lg:mr-32 grid grid-cols-1 lg:grid-cols-3 gap-8">

--- a/frontend/components/ui/footer.jsx
+++ b/frontend/components/ui/footer.jsx
@@ -63,7 +63,7 @@ export default function Component() {
 
                     <ul>
                         <li className="mb-2"><a href="/blog">Blog</a></li>
-                        <li className="mb-2">Resource Library</li>
+                        <li className="mb-2"><a href="/resources">Resource Library</a></li>
                         <li className="mb-2">Developers</li>
                         <li className="mb-2">App Connectors</li>
                         <li className="mb-2"><a href="/support">Support</a></li>


### PR DESCRIPTION
## PR Description

### Summary
- Linked the footer `Resource Library` item to the `/resources` page.
- Updated the resources page title to `Resource Library`.
- Improved the resources page subtitle to better describe the page content.

### Files Changed
- footer.jsx
- page.jsx

### Notes
- This makes the footer navigation consistent with the existing `Resources` route.
- The Resource Library page is now clearly labeled and easier for users to find.