### PR TITLE
Add Press center with backend API and frontend news pages

### DIFF
--- a/frontend/app/press/[slug]/page.jsx
+++ b/frontend/app/press/[slug]/page.jsx
@@ -1,0 +1,47 @@
+"use client"
+
+import React, { useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { useRouter } from 'next/router'
+
+export default function PressDetail({ params }) {
+  const { slug } = params || {};
+  const [item, setItem] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      if (!slug) return;
+      try {
+        const res = await fetch(`http://localhost:3005/press/${slug}`);
+        if (!res.ok) throw new Error('Failed to fetch');
+        const data = await res.json();
+        setItem(data);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [slug]);
+
+  if (loading) return <p className="container mx-auto px-4 py-10">Loading…</p>;
+  if (!item) return <p className="container mx-auto px-4 py-10">Not found</p>;
+
+  return (
+    <main className="container mx-auto px-4 py-12">
+      <Card>
+        <CardHeader>
+          <CardTitle>{item.title}</CardTitle>
+          <CardDescription>{item.summary}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">{new Date(item.publishedAt).toLocaleDateString()} — {item.author}</p>
+          <div className="prose max-w-none mt-4" dangerouslySetInnerHTML={{ __html: item.content || item.summary }} />
+          {item.sourceUrl && <p className="mt-4"><a href={item.sourceUrl} target="_blank" rel="noreferrer" className="text-[#A437DB]">Read original source</a></p>}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/frontend/app/press/page.jsx
+++ b/frontend/app/press/page.jsx
@@ -1,0 +1,91 @@
+"use client"
+
+import React, { useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import Link from "next/link";
+
+export default function PressPage() {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch("http://localhost:3005/press");
+        if (!res.ok) throw new Error("Failed to fetch");
+        const data = await res.json();
+        setItems(data || []);
+      } catch (err) {
+        console.error(err);
+        setItems([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  const featured = items.length ? items[0] : null;
+  const rest = items.slice(1);
+
+  return (
+    <main className="min-h-screen bg-white text-black">
+      <section className="container mx-auto px-4 py-20">
+        <h1 className="text-4xl lg:text-5xl font-bold text-[#A437DB] mb-4">Press & News</h1>
+        <p className="text-lg text-muted-foreground max-w-2xl">Latest company announcements, press releases, and media coverage.</p>
+      </section>
+
+      <section className="container mx-auto px-4 py-8">
+        {loading ? (
+          <p>Loading...</p>
+        ) : (
+          <>
+            {featured && (
+              <Card className="mb-8">
+                <CardHeader>
+                  <CardTitle>{featured.title}</CardTitle>
+                  <CardDescription>{featured.summary}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <p className="mb-4 text-sm text-muted-foreground">{new Date(featured.publishedAt).toLocaleDateString()} — {featured.author}</p>
+                  <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: featured.content || featured.summary }} />
+                  {featured.sourceUrl && (
+                    <p className="mt-4"><a href={featured.sourceUrl} target="_blank" rel="noreferrer" className="text-[#A437DB]">Read original source</a></p>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+
+            <div className="grid gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+              {rest.map((item) => (
+                <Card key={item._id}>
+                  <CardHeader>
+                    <CardTitle className="text-lg">{item.title}</CardTitle>
+                    <CardDescription>{item.summary}</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-muted-foreground">{new Date(item.publishedAt).toLocaleDateString()} • {item.author}</p>
+                    <div className="mt-4">
+                      <Link href={`/press/${item.slug}`} className="text-[#A437DB]">Read more</Link>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+
+            <div className="mt-12 flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+              <div>
+                <h3 className="text-2xl font-semibold">Press Kit</h3>
+                <p className="text-sm text-muted-foreground">Download our brand assets and company information for media use.</p>
+              </div>
+              <div className="flex items-center gap-4">
+                <a href="/press-kit.pdf" className="inline-block rounded bg-[#A437DB] text-white px-4 py-2">Download Press Kit</a>
+                <a href="mailto:press@snapshorturl.example" className="text-sm text-muted-foreground">Contact: press@snapshorturl.example</a>
+              </div>
+            </div>
+          </>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/frontend/components/ui/footer.jsx
+++ b/frontend/components/ui/footer.jsx
@@ -8,18 +8,17 @@ export default function Component() {
                 <div>
                     <h2 className="lg:text-2xl md:text-2xl font-bold mb-2 sm:text-xl">SnapshortURL</h2>
                     <p className="mb-4">Streamlined URL Shortening for the Modern Web</p>
-                    <a href="/">
-                    <Image
-                        alt="Great Place to Work Certified"
-                        className="mb-6 pl-0"
-                        height="200"
-                        src="/SnapshortURL.svg"
-                        style={{
-                            aspectRatio: "120/40",
-                            objectFit: "cover",
-                        }}
-                        width="200"
-                    />
+                    <a href="/" aria-label="SnapshortURL homepage">
+                        <Image
+                            alt="SnapshortURL logo"
+                            className="mb-6 pl-0"
+                            width={120}
+                            height={40}
+                            src="/SnapshortURL.svg"
+                            style={{
+                                objectFit: "cover",
+                            }}
+                        />
                     </a>
                     <p className="text-sm">Follow us:</p>
                     <div className="flex space-x-4 mt-2">
@@ -48,13 +47,13 @@ export default function Component() {
                         <li className="mb-2">Customer Service For Developers</li>
                     </ul>
                 </div>
-
+                        
                 <div>
                     <h3 className="font-semibold mb-3">Features</h3>
                     <ul>
 
-                        <li className="mb-2">Branded Links</li>
-                        <li className="mb-2">Mobile Links</li>
+                        <li className="mb-2"><a href="/branded-links">Branded Links</a></li>
+                        <li className="mb-2"><a href="/mobile-app">Mobile App</a></li>
                         <li className="mb-2">Campaign Management & Analytics</li>
                     </ul>
                 </div>
@@ -68,8 +67,8 @@ export default function Component() {
                         <li className="mb-2"><Link href="/developers">Developers</Link></li>
                         <li className="mb-2"><Link href="/app-connectors">App Connectors</Link></li>
                         <li className="mb-2"><a href="/support">Support</a></li>
-                        <li className="mb-2"><a href="/trustcenter">Trust Center</a></li>
-                        <li className="mb-2">Browser Extension</li>
+                        <li className="mb-2"><Link href="/trustcenter">Trust Center</Link></li>
+                        <li className="mb-2"><Link href="/browser-extension">Browser Extension</Link></li>
                         <li className="mb-2">Mobile App</li>
                     </ul>
 
@@ -81,7 +80,7 @@ export default function Component() {
                         <li className="mb-2"><a href="/career">Careers</a></li>
                         <li className="mb-2">Diversity & Inclusion</li>
                         <li className="mb-2"><a href="/partner">Partners</a></li>
-                        <li className="mb-2">Press</li>
+                        <li className="mb-2"><a href="/press">Press</a></li>
                         <li className="mb-2"><a href="/contactus">Contact</a></li>
                         <li className="mb-2"><a href="/review">Reviews</a></li>
                     </ul>

--- a/frontend/components/ui/footer.jsx
+++ b/frontend/components/ui/footer.jsx
@@ -80,7 +80,7 @@ export default function Component() {
                         <li className="mb-2"><a href="/career">Careers</a></li>
                         <li className="mb-2">Diversity & Inclusion</li>
                         <li className="mb-2"><a href="/partner">Partners</a></li>
-                        <li className="mb-2">Press</li>
+                        <li className="mb-2"><a href="/press">Press</a></li>
                         <li className="mb-2"><a href="/contactus">Contact</a></li>
                         <li className="mb-2"><a href="/review">Reviews</a></li>
                     </ul>

--- a/frontend/public/press-kit.pdf
+++ b/frontend/public/press-kit.pdf
@@ -1,0 +1,1 @@
+Placeholder press kit for development. Replace with actual press-kit PDF.


### PR DESCRIPTION
Suggested PR description:
- Implements a new Press section for SnapShortURL.
- Adds backend `/press` API endpoints, model, controller, and routing.
- Adds frontend press listing and detail pages.
- Adds footer navigation to `/press`.
- Includes a placeholder `press-kit.pdf` for press kit download.
- Supports local dev fallback data when MongoDB is unavailable.